### PR TITLE
clock can from 16mhz xtal

### DIFF
--- a/FlexCAN.cpp
+++ b/FlexCAN.cpp
@@ -15,7 +15,7 @@ FlexCAN::FlexCAN(uint32_t baud)
   // set up the pins, 3=PTA12=CAN0_TX, 4=PTA13=CAN0_RX
   CORE_PIN3_CONFIG = PORT_PCR_MUX(2);
   CORE_PIN4_CONFIG = PORT_PCR_MUX(2);// | PORT_PCR_PE | PORT_PCR_PS;
-  // select clock source
+  // select clock source 16MHz xtal
   OSC0_CR |= OSC_ERCLKEN;
   SIM_SCGC6 |=  SIM_SCGC6_FLEXCAN0;
   FLEXCAN0_CTRL1 &= ~FLEXCAN_CTRL_CLK_SRC;
@@ -38,7 +38,7 @@ FlexCAN::FlexCAN(uint32_t baud)
   //enable RX FIFO
   FLEXCAN0_MCR |= FLEXCAN_MCR_FEN;
 
-  // segment timings from freescale loopback test
+  // segment splits and clock divisor based on baud rate
   if ( 250000 == baud ) {
     FLEXCAN0_CTRL1 = (FLEXCAN_CTRL_PROPSEG(2) | FLEXCAN_CTRL_RJW(1)
                       | FLEXCAN_CTRL_PSEG1(7) | FLEXCAN_CTRL_PSEG2(3) | FLEXCAN_CTRL_PRESDIV(3));

--- a/FlexCAN.h
+++ b/FlexCAN.h
@@ -7,11 +7,6 @@
 
 #include <Arduino.h>
 
-// in the short term insure 48MHz bus speed
-#if F_BUS != 48000000
-#error "Only CPU speeds 48, 96 and 144 are supported"
-#endif
-
 typedef struct CAN_message_t {
   uint32_t id; // can identifier
   uint8_t ext; // identifier is extended

--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ Note that CAN will normally not work without termination resistors.
 
 Supported baud rates are 125000, 250000, 500000, and 1000000 bits per second.  If the baud rate is not specified it will default to 125000.
 
-Please note that **only CPU speeds 48, 96 and 144 are supported** presently.
-
 ###CAN Transceiver Options
 Please add parts you are using successfully with Teensy 3.1 to this list.
 - TI SN65HVD230D on 3.3V (1MBPS)


### PR DESCRIPTION
Switch CAN0 clock source from the 48MHz bus clock to the 16MHz xtal clock.  Update bit phase timings accordingly. 
