### PR TITLE
Tested MCP2551 and MCP2561 CAN transceivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Please add parts you are using successfully with Teensy 3.1 to this list.
 - TI SN65HVD230D on 3.3V (1MBPS)
 - TI SN65HVD232D / SN65HVD232QDQ1 on 3.3V (1MBPS)
 - NXP TJA1050T/VM,118 on the same 5V supply as the Teensy. (1MBPS)
-- Microchip MCP2551 on 5V (reported at 500KBPS)
+- Microchip MCP2551 on 5V (1MBPS)
+- Microchip MCP2561 on 5V (1MBPS)
 - Linear LT1796 on 5V (not speedtested)
 
 ###Driver API


### PR DESCRIPTION
Tested MCP2551 and MCP2561 both at 500 Kbps and 1Mbps.